### PR TITLE
Use gql query as string instead of the internal dsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ pubspec.lock
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/
+
+# GraphQL IDE completion
+graphql.config.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,14 +17,13 @@ GQL query you built and is handling reconciliation between the HTTP response and
 ## Roadmap
 - `QueryBuilder`:
   - [ ] Builder
-  - [ ] Fields
-  - [ ] Alias
-  - [ ] Arguments
+  - [x] Fields
+  - [x] Arguments
   - [ ] Aliases
-  - [ ] Fragments
+  - [x] Fragments
   - [ ] Variables
-  - [ ] Directives
-  - [ ] **Optionnal** Inline Fragments
+  - [x] Directives
+  - [x] **Optionnal** Inline Fragments
 - `VariableBuilder`:
   - [ ] Builder
 - `MutationBuilder`:
@@ -33,6 +32,7 @@ GQL query you built and is handling reconciliation between the HTTP response and
   - [ ] Variables
 - `QueryReconcilier`:
   - [ ] Reconciler
+  - [ ] Reconcile Aliases
 - `Scalar Types`:
   - [ ] Implements default types
 - `GraphQLAnnotations` (used to define queries and mutations):
@@ -40,9 +40,9 @@ GQL query you built and is handling reconciliation between the HTTP response and
   - [ ] Field directive
   - [ ] Field alias
 - `GraphQLClient`:
-  - [ ] Factory
+  - [x] Factory
   - [ ] GraphQL Response
 - [ ] **Optionnal** GraphQL dart classes generation from a GQL schema
-- [ ] **Optionnal** Translate GQL queries from String to `graphql_client` DSL
+- [x] **Optionnal** Translate GQL queries from String to `graphql_client` DSL
    
 [1]: http://facebook.github.io/graphql/

--- a/example/github_declarations.dart
+++ b/example/github_declarations.dart
@@ -7,7 +7,6 @@ import 'package:graphql_client/graphql_client.dart';
 class GithubGraphQLSchema implements Schema {
   Viewer viewer;
 
-  GithubGraphQLSchema({this.viewer});
   GithubGraphQLSchema.fromJSON(Map data)
       : viewer = new Viewer.fromJSON(data['viewer']);
 
@@ -21,13 +20,12 @@ ${indentLines(viewer.toString(), 4)}
   }
 }
 
-class Viewer {
+class Viewer implements Schema {
   GraphQLString login;
   GraphQLString avatarUrl;
   GraphQLString bio;
   GraphQLConnection<Gist> gists;
 
-  Viewer({this.login, this.avatarUrl, this.bio, this.gists});
   Viewer.fromJSON(Map data)
       : login = new GraphQLString(data['login']),
         avatarUrl = new GraphQLString(data['avatarUrl']),
@@ -46,11 +44,10 @@ ${indentLines(gists.toString(), 2)}
   }
 }
 
-class Gist {
+class Gist implements Schema {
   GraphQLString name;
   GraphQLString description;
 
-  Gist({this.name, this.description});
   Gist.fromJSON(Map data)
       : name = new GraphQLString(data['name']),
         description = new GraphQLString(data['description']);

--- a/example/github_declarations.dart
+++ b/example/github_declarations.dart
@@ -4,11 +4,12 @@
 
 import 'package:graphql_client/graphql_client.dart';
 
-class Query {
+class GithubGraphQLSchema implements Schema {
   Viewer viewer;
 
-  Query({this.viewer});
-  Query.fromJSON(Map data) : viewer = new Viewer.fromJSON(data['viewer']);
+  GithubGraphQLSchema({this.viewer});
+  GithubGraphQLSchema.fromJSON(Map data)
+      : viewer = new Viewer.fromJSON(data['viewer']);
 
   @override
   String toString() {

--- a/example/github_declarations.dart
+++ b/example/github_declarations.dart
@@ -23,10 +23,8 @@ ${indentLines(viewer.toString(), 4)}
 
 class Viewer {
   GraphQLString login;
-  @GraphQLArguments('size: 200')
   GraphQLString avatarUrl;
   GraphQLString bio;
-  @GraphQLArguments('last: 2')
   GraphQLConnection<Gist> gists;
 
   Viewer({this.login, this.avatarUrl, this.bio, this.gists});

--- a/example/graphql_client_example.dart
+++ b/example/graphql_client_example.dart
@@ -27,8 +27,7 @@ main() async {
     client: client,
     logger: logger,
     endPoint: endPoint,
-    schema: new GithubGraphQLSchema(),
-  );
+  )..loadSchema(new GithubGraphQLSchema());
 
   //language=GraphQL
   String gqlQuery = '''
@@ -47,7 +46,7 @@ main() async {
     }
   ''';
 
-  GithubGraphQLSchema res = await graphQLClient.execute(
+  var res = await graphQLClient.execute<GithubGraphQLSchema>(
     gqlQuery,
     headers: {'Authorization': 'bearer $apiToken'},
   );

--- a/example/graphql_client_example.dart
+++ b/example/graphql_client_example.dart
@@ -27,7 +27,7 @@ main() async {
     client: client,
     logger: logger,
     endPoint: endPoint,
-  )..loadSchema(new GithubGraphQLSchema());
+  )..loadSchema(GithubGraphQLSchema);
 
   //language=GraphQL
   String gqlQuery = '''
@@ -35,14 +35,18 @@ main() async {
       viewer {
         avatarUrl(size: 200)
         login
-        bio
+        bio @include(if: false)
         gists(first: 5) {
           nodes {
-            name
-            description
+            ...ShortGist
           }
         }
       }
+    }
+    
+    fragment ShortGist on Gist {
+      name
+      description
     }
   ''';
 
@@ -52,4 +56,5 @@ main() async {
   );
 
   print(res.viewer.avatarUrl.value);
+  print(res.viewer.gists.nodes.first.name.value);
 }

--- a/example/graphql_client_example.dart
+++ b/example/graphql_client_example.dart
@@ -27,24 +27,30 @@ main() async {
     client: client,
     logger: logger,
     endPoint: endPoint,
+    schema: new GithubGraphQLSchema(),
   );
 
-  Query builtQuery = new Query(
-    viewer: new Viewer(
-      avatarUrl: new GraphQLString(),
-      login: new GraphQLString(),
-      bio: new GraphQLString(),
-      gists: new GraphQLConnection<Gist>(
-        nodes: new Gist(
-          name: new GraphQLString(),
-          description: new GraphQLString(),
-        ),
-      ),
-    ),
-  );
+  //language=GraphQL
+  String gqlQuery = '''
+    query {
+      viewer {
+        avatarUrl(size: 200)
+        login
+        bio
+        gists(first: 5) {
+          nodes {
+            name
+            description
+          }
+        }
+      }
+    }
+  ''';
 
-  await graphQLClient.execute<Query>(
-    builtQuery,
+  GithubGraphQLSchema res = await graphQLClient.execute(
+    gqlQuery,
     headers: {'Authorization': 'bearer $apiToken'},
   );
+
+  print(res.viewer.avatarUrl.value);
 }

--- a/lib/query_builder.dart
+++ b/lib/query_builder.dart
@@ -5,6 +5,7 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
+@Deprecated('Not used anymore')
 library graphql_client.query_builder;
 
 export 'src/query_builder.dart';

--- a/lib/schema.dart
+++ b/lib/schema.dart
@@ -5,12 +5,6 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
-library graphql_client;
+library graphql_client.schema;
 
-export 'client.dart';
-export 'utils.dart';
-export 'annotations.dart';
-export 'scalar_types.dart';
-export 'connection.dart';
-export 'query_reconcilier.dart';
-export 'schema.dart';
+export 'src/schema.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -6,27 +6,32 @@ library graphql_client.src.client;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:mirrors';
 
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
-import 'query_builder.dart';
 import 'query_reconcilier.dart';
+import 'schema.dart';
 
 class GraphQLClient {
   Client client;
   String endPoint;
   Logger logger;
+  Schema schema;
+  ClassMirror _schemaMirror;
 
   GraphQLClient({
     this.client,
     this.endPoint,
     this.logger,
-  });
+    this.schema,
+  })
+      : _schemaMirror = reflect(schema).type;
 
-  Future<T> execute<T>(T query,
+  Future<T> execute<T extends Schema>(String gqlQuery,
       {Map<String, String> headers = const {}}) async {
-    String gqlQuery = queryBuilder<T>(query);
+//    String gqlQuery = queryBuilder<T>(query);
 
     logger.finest('Query: $gqlQuery');
 
@@ -38,7 +43,7 @@ class GraphQLClient {
 
     logger.finest('Response: ${response.body}');
 
-    T reconciliedQuery = reconcileResponse<T>(query, response.body);
+    T reconciliedQuery = reconcileResponse(_schemaMirror, response.body);
 
     logger.finest('Result: \n$reconciliedQuery');
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -26,8 +26,8 @@ class GraphQLClient {
     this.logger,
   });
 
-  void loadSchema(Schema schema) {
-    _schemaMirror = reflect(schema).type;
+  void loadSchema(Type schemaClass) {
+    _schemaMirror = reflectClass(schemaClass);
   }
 
   Future<T> execute<T extends Schema>(String gqlQuery,
@@ -38,11 +38,13 @@ class GraphQLClient {
 
     logger.finest('Query: $gqlQuery');
 
-    var response = await client.post(endPoint,
-        headers: headers,
-        body: JSON.encode(
-          {'query': gqlQuery},
-        ));
+    var response = await client.post(
+      endPoint,
+      headers: headers,
+      body: JSON.encode(
+        {'query': gqlQuery},
+      ),
+    );
 
     logger.finest('Response: ${response.body}');
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -18,20 +18,23 @@ class GraphQLClient {
   Client client;
   String endPoint;
   Logger logger;
-  Schema schema;
   ClassMirror _schemaMirror;
 
   GraphQLClient({
     this.client,
     this.endPoint,
     this.logger,
-    this.schema,
-  })
-      : _schemaMirror = reflect(schema).type;
+  });
+
+  void loadSchema(Schema schema) {
+    _schemaMirror = reflect(schema).type;
+  }
 
   Future<T> execute<T extends Schema>(String gqlQuery,
       {Map<String, String> headers = const {}}) async {
-//    String gqlQuery = queryBuilder<T>(query);
+    if (_schemaMirror == null) {
+      throw new StateError("You must load a schema before executing a query");
+    }
 
     logger.finest('Query: $gqlQuery');
 
@@ -43,7 +46,7 @@ class GraphQLClient {
 
     logger.finest('Response: ${response.body}');
 
-    T reconciliedQuery = reconcileResponse(_schemaMirror, response.body);
+    T reconciliedQuery = reconcileResponse<T>(_schemaMirror, response.body);
 
     logger.finest('Result: \n$reconciliedQuery');
 

--- a/lib/src/query_builder.dart
+++ b/lib/src/query_builder.dart
@@ -9,6 +9,7 @@ import 'dart:mirrors';
 import 'annotations.dart';
 import 'connection.dart';
 
+@Deprecated('Not used anymore')
 String buildInstanceQuery(InstanceMirror instanceMirror) {
   ClassMirror classMirror = instanceMirror.type;
   var classDeclarations = classMirror.declarations;
@@ -60,6 +61,7 @@ String buildInstanceQuery(InstanceMirror instanceMirror) {
   return '{ ${gqlQuery.trim()} }';
 }
 
+@Deprecated('Not used anymore')
 String queryBuilder<T>(T query) {
   InstanceMirror queryInstanceMirror = reflect(query);
   String gqlQuery = buildInstanceQuery(queryInstanceMirror);

--- a/lib/src/query_reconcilier.dart
+++ b/lib/src/query_reconcilier.dart
@@ -7,10 +7,9 @@ library graphql_client.src.query_reconcilier;
 import 'dart:mirrors';
 import 'dart:convert';
 
-T reconcileResponse<T>(T query, String response) {
+reconcileResponse<T>(ClassMirror schemaMirror, String response) {
   Map jsonResponse = JSON.decode(response);
-  ClassMirror classMirror = reflect(query).type;
 
-  return classMirror
+  return schemaMirror
       .newInstance(const Symbol('fromJSON'), [jsonResponse['data']]).reflectee;
 }

--- a/lib/src/query_reconcilier.dart
+++ b/lib/src/query_reconcilier.dart
@@ -7,7 +7,7 @@ library graphql_client.src.query_reconcilier;
 import 'dart:mirrors';
 import 'dart:convert';
 
-reconcileResponse<T>(ClassMirror schemaMirror, String response) {
+T reconcileResponse<T>(ClassMirror schemaMirror, String response) {
   Map jsonResponse = JSON.decode(response);
 
   return schemaMirror

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -1,0 +1,7 @@
+// Copyright Thomas Hourlier. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+library graphql_client.src.schema;
+
+abstract class Schema {}

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -4,4 +4,7 @@
 
 library graphql_client.src.schema;
 
-abstract class Schema {}
+abstract class Schema {
+  Schema();
+  Schema.fromJSON(Map data);
+}

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -5,6 +5,5 @@
 library graphql_client.src.schema;
 
 abstract class Schema {
-  Schema();
   Schema.fromJSON(Map data);
 }


### PR DESCRIPTION
Fixes #1 .

Caveats:
* How to handle GraphQL aliases properly?

Sample of code:

```dart
  final client = new Client();
  final logger = new Logger('GraphQLClient');
  final graphQLClient = new GraphQLClient(
    client: client,
    logger: logger,
    endPoint: endPoint,
  )..loadSchema(GithubGraphQLSchema);

  //language=GraphQL
  String gqlQuery = '''
    query {
      viewer {
        avatarUrl(size: 200)
        login
        bio @include(if: false)
        gists(first: 5) {
          nodes {
            ...ShortGist
          }
        }
      }
    }
    
    fragment ShortGist on Gist {
      name
      description
    }
  ''';

  var res = await graphQLClient.execute<GithubGraphQLSchema>(
    gqlQuery,
    headers: {'Authorization': 'bearer $apiToken'},
  );

  print(res.viewer.avatarUrl.value);
  print(res.viewer.gists.nodes.first.name.value);
```