### PR TITLE
Fix to Client edges processing

### DIFF
--- a/graphql_client/README.md
+++ b/graphql_client/README.md
@@ -38,7 +38,7 @@ class ViewerBioQuery extends Object with Fields implements GQLOperation {
   ViewerResolver viewer = new ViewerResolver();
 
   @override
-  OperationType get type => OperationType.query;
+  String get type => queryType;
 
   @override
   String get name => 'ViewerBioQuery';

--- a/graphql_client/lib/src/client.dart
+++ b/graphql_client/lib/src/client.dart
@@ -158,7 +158,7 @@ class GQLClient {
 
       if (edgeResolver != null) {
         resolver.edges =
-            new List.generate(nodesData.length, (_) => edgeResolver.clone());
+            new List.generate(edgesData.length, (_) => edgeResolver.clone());
 
         for (var i = 0; i < edgesData.length; i++) {
           _resolveQuery(resolver.edges[i], edgesData[i]);


### PR DESCRIPTION
Two things:

1. Just a small update to the README to follow the code in `queries_examples.dart`
2. Use `edgesData.length` instead of `nodesData.length` when using the `edgeResolver`. Found this after I was getting some null errors.

resolves #15 